### PR TITLE
Remove maven cache

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,13 +20,6 @@ jobs:
           distribution: 'temurin'
           architecture: x64
 
-      - name: Cache Maven dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ github.base_ref }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-${{ github.base_ref }}
-
       - name: Clean and build
         run: mvn -B -e clean install -DskipTests
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
+          key: ${{ runner.os }}-maven-${{ github.base_ref }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-${{ github.base_ref }}
 
       - name: Clean and build
         run: mvn -B -e clean install -DskipTests


### PR DESCRIPTION
File renamed to run-tests.

Removed the cache configuration from the yml file because Git actions create a cache for each open PR (see image below). This way, the cache can only be used in your own PR and in no other.

I tried to configure to all PRs used the same cache or the cache was deleted after the PR was closed or merged, but I couldn't do it. I then decided to remove the option so as not to overfill the space provided by GitHub.

![image](https://github.com/Matheusstreisky/virtual-showcase-backend/assets/13373849/713ecaa7-db7e-467e-b5c8-2a7ac48b4fe7)
